### PR TITLE
Bump python support up to version 3.11

### DIFF
--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,8 +1,13 @@
 {
   "acceptedPythonInterpreters": [
     "PYTHON36",
-    "PYTHON37"
+    "PYTHON37",
+    "PYTHON38",
+    "PYTHON39",
+    "PYTHON310",
+    "PYTHON311"
   ],
+  "corePackagesSet": "AUTO",
   "forceConda": false,
   "installCorePackages": true,
   "installJupyterSupport": true

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,7 +1,8 @@
 pdf2image==1.14.0
 pytesseract==0.3.7
 Pillow==8.1.0
-matplotlib==3.3.4
+matplotlib==3.3.4; python_version <= '3.9'
+matplotlib==3.7.1; python_version >= '3.10'
 opencv-python==4.5.1.48; python_version <= '3.9'
 opencv-python==4.7.0.72; python_version >= '3.10'
 deskew==0.10.3

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -2,5 +2,6 @@ pdf2image==1.14.0
 pytesseract==0.3.7
 Pillow==8.1.0
 matplotlib==3.3.4
-opencv-python==4.5.1.48
+opencv-python==4.5.1.48; python_version <= '3.9'
+opencv-python==4.7.0.72; python_version >= '3.10'
 deskew==0.10.3


### PR DESCRIPTION
This PR adds support for python 3.8, 3.9, 3.10 and 3.11, and bumps the plugin code env dependencies where necessary