### PR TITLE
text extraction: Do not use line wrap for markdown conversion when chunking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Version 2.3.1](https://github.com/dataiku/dss-plugin-tesseract-ocr/releases/tag/v2.3.1) - Patch release - 2024-01
+
+- Fix text extraction from html files with line wraps when chunking
+
 ## [Version 2.3.0](https://github.com/dataiku/dss-plugin-tesseract-ocr/releases/tag/v2.3.0) - Minor release - 2023-12
 
 - Add ability to extract text chunks from PDF using bookmarks positions

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "tesseract-ocr",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "meta": {
         "label": "Text extraction and OCR",
         "description": "Extract text from documents & images.",

--- a/python-lib/text_extraction/__init__.py
+++ b/python-lib/text_extraction/__init__.py
@@ -88,7 +88,9 @@ def extract_text_chunks(filename, file_bytes, extension, with_pandoc, metadata_a
             with tempfile.NamedTemporaryFile(dir=temporary_job_folder, suffix=".{}".format(extension)) as tmp:
                 tmp.write(file_bytes)
                 # 'gfm' is for markdown_github, a simplified form of markdown for more consistent results across OSes
-                markdown = pypandoc.convert_file(tmp.name, to="gfm", format=extension)
+                # We use the `--wrap none` argument to avoid line wraps in the conversion output, that could lead to
+                # incorrect markdown chunk extraction
+                markdown = pypandoc.convert_file(tmp.name, to="gfm", format=extension, extra_args=("--wrap", "none"))
 
                 if not markdown.strip():
                     raise ValueError("Content is empty after converting to markdown.")


### PR DESCRIPTION
# To verify

Use an input html file with newlines within a html tag, e.g.:

```html
<h2>Titre<a href="#anchor"
    title="Permalink to this headline">§</a></h2>
```

Check that the result of text extraction recipe (with chunk extraction) gives correct chunk headers